### PR TITLE
Add Docker setup for Flask application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__
+*.pyc
+.git
+.gitignore
+*.db
+*.log
+*.gz
+*.egg-info
+
+# Tests and local files
+tests
+webinterface
+conf
+etc
+.tos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+WORKDIR /app
+
+# Install build tools and MySQL client libraries
+RUN apt-get update \
+    && apt-get install -y gcc default-libmysqlclient-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy application code
+COPY . /app
+
+# Install python dependencies
+RUN pip install --no-cache-dir \
+        Flask==2.2.5 \
+        SQLAlchemy \
+        mysqlclient
+
+# Default database connection
+ENV CH_DBURL mysql://chuser:chpass@db/ch?connect_timeout=1
+
+EXPOSE 5000
+CMD ["python", "flaskapp/app.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Cogent House Docker Setup
+
+This repository includes a small example Flask application in `flaskapp/`.
+The provided Docker configuration launches the app using **Python 3** and
+runs a MySQL server alongside it via Docker Compose.
+
+## Usage
+
+1. Build and start the services:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The Flask application will be available on [http://localhost:5000](http://localhost:5000).
+
+2. The database credentials are defined in `docker-compose.yml` and the
+   Flask container uses the `CH_DBURL` environment variable to connect.
+
+3. To stop the containers:
+
+   ```bash
+   docker compose down
+   ```
+
+The MySQL data is stored in a named Docker volume `dbdata` so that data is
+preserved between restarts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: ch
+      MYSQL_USER: chuser
+      MYSQL_PASSWORD: chpass
+    volumes:
+      - dbdata:/var/lib/mysql
+
+  web:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - "5000:5000"
+    environment:
+      CH_DBURL: mysql://chuser:chpass@db/ch?connect_timeout=1
+
+volumes:
+  dbdata:


### PR DESCRIPTION
## Summary
- add Dockerfile for Flask application
- add docker-compose configuration with MySQL service
- ignore unnecessary files in Docker context
- document how to run the containers
- update Dockerfile to Python 3

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'unittest2')*

------
https://chatgpt.com/codex/tasks/task_e_68719d1ab8e88327afba27a1b2881b43