### PR TITLE
Refactor docker compose layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ runs a MySQL server alongside it via Docker Compose.
    docker compose down
    ```
 
-The MySQL data is stored in a named Docker volume `dbdata` so that data is
-preserved between restarts.
+The MySQL data is stored in the `./dbdata` directory on the host so that data
+is preserved between restarts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,19 @@
-version: '3.8'
-services:
-  db:
-    image: mysql:5.7
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: ch
-      MYSQL_USER: chuser
-      MYSQL_PASSWORD: chpass
-    volumes:
-      - dbdata:/var/lib/mysql
+db:
+  image: mysql:5.7
+  restart: always
+  environment:
+    MYSQL_ROOT_PASSWORD: rootpassword
+    MYSQL_DATABASE: ch
+    MYSQL_USER: chuser
+    MYSQL_PASSWORD: chpass
+  volumes:
+    - ./dbdata:/var/lib/mysql
 
-  web:
-    build: .
-    depends_on:
-      - db
-    ports:
-      - "5000:5000"
-    environment:
-      CH_DBURL: mysql://chuser:chpass@db/ch?connect_timeout=1
-
-volumes:
-  dbdata:
+web:
+  build: .
+  depends_on:
+    - db
+  ports:
+    - "5000:5000"
+  environment:
+    CH_DBURL: mysql://chuser:chpass@db/ch?connect_timeout=1


### PR DESCRIPTION
## Summary
- remove Compose version and flatten service definitions
- switch from a named volume to a host directory for MySQL data
- document new host directory usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cogent')*

------
https://chatgpt.com/codex/tasks/task_e_687799f9b0a88327b4d529572be4e312