### PR TITLE
Recover temp logs on startup

### DIFF
--- a/pulp/base/FlatLogger.py
+++ b/pulp/base/FlatLogger.py
@@ -53,12 +53,56 @@ class FlatLogger(object):
         self.log = logging.getLogger("flatlogger")
         self.running = True
         self.first = True
+
+        # Recover any files left in the temporary directory from previous runs.
+        self._process_tmp_dir()
+
         time_string = time.strftime("%Y_%j_%H-%M", time.gmtime())
         self.out_fname = "%s_%s.log" % (time_string, HOST_NAME)
         self.log_fname = "%s/%s" % (self.tmp_dir, self.out_fname)
         self.log.debug("Logging directory %s" % (self.log_fname))
         print(f"opening {self.log_fname}")
         self.tmp_file = open(self.log_fname, "w")
+
+    def _process_tmp_dir(self):
+        """Handle any files left in the temporary directory from a previous run."""
+        try:
+            for entry in os.scandir(self.tmp_dir):
+                if not entry.is_file():
+                    continue
+                valid = True
+                try:
+                    with open(entry.path, "r") as fh:
+                        for line in fh:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                json.loads(line)
+                            except Exception:
+                                valid = False
+                                break
+                except OSError as e:
+                    self.log.exception(e)
+                    continue
+
+                if valid:
+                    try:
+                        os.rename(entry.path, os.path.join(self.out_dir, entry.name))
+                        self.log.info(
+                            "Recovered temporary log %s", entry.name
+                        )
+                    except OSError as e:
+                        self.log.exception(e)
+                else:
+                    self.log.warning("Removing corrupt temp file %s", entry.name)
+                    try:
+                        os.remove(entry.path)
+                    except OSError as e:
+                        self.log.exception(e)
+        except FileNotFoundError:
+            # tmp_dir may not exist yet; nothing to recover
+            pass
 
     def send_ack(self, seq=None, dest=None):
         """send acknowledgement message"""

--- a/tests/test_flat.py
+++ b/tests/test_flat.py
@@ -6,14 +6,116 @@ J. Brusey, May 2011
 
 import logging
 import re
+import json
 from queue import Queue
 from unittest.mock import MagicMock, mock_open, patch
+import types
+import sys
+import pulp
+
+node_module = types.ModuleType("pulp.node")
+
+
+class AckMsg:
+    def set_seq(self, seq):
+        self.seq = seq
+
+    def set_node_id(self, node_id):
+        self.node_id = node_id
+
+
+class Packets:
+    SPECIAL = 0xC7
+    AM_BOOTMSG = 1
+    AM_STATEMSG = 2
+    SC_PACKED_SIZE = 16
+
+
+node_module.AckMsg = AckMsg
+node_module.Packets = Packets
+node_module.StateMsg = object
+node_module.ConfigMsg = object
+node_module.BootMsg = object
+sys.modules["pulp.node"] = node_module
+setattr(pulp, "node", node_module)
+
+tinyos_module = types.ModuleType("tinyos3")
+tinyos_message_module = types.ModuleType("tinyos3.message")
+
+
+class MoteIF:
+    @staticmethod
+    def set_debug_level(level):
+        pass
+
+
+tinyos_message_module.MoteIF = MoteIF
+sys.modules["tinyos3"] = tinyos_module
+sys.modules["tinyos3.message"] = tinyos_message_module
 
 from pulp.base.FlatLogger import FlatLogger
 
 # sys.path.append(os.environ["TOSROOT"] + "/tools/tinyos/python/")
 # sys.path.append("../..")
-from pulp.node import StateMsg
+# Minimal StateMsg stand-in for testing without tinyos3 dependencies
+class StateMsg:
+    def __init__(self, addr=0):
+        self._addr = addr
+        self._ctp_parent_id = 0
+        self._timestamp = 0
+        self._special = 0
+        self._seq = 0
+        self._rssi = 0
+        self._mask = 0
+        self._packed = {}
+
+    def set_ctp_parent_id(self, value):
+        self._ctp_parent_id = value
+
+    def get_ctp_parent_id(self):
+        return self._ctp_parent_id
+
+    def set_timestamp(self, value):
+        self._timestamp = value
+
+    def get_timestamp(self):
+        return self._timestamp
+
+    def set_special(self, value):
+        self._special = value
+
+    def get_special(self):
+        return self._special
+
+    def setElement_packed_state_mask(self, index, value):
+        if value:
+            self._mask |= 1 << index
+        else:
+            self._mask &= ~(1 << index)
+
+    def get_packed_state_mask(self):
+        return [self._mask, 0]
+
+    def totalSizeBits_packed_state_mask(self):
+        return 16
+
+    def setElement_packed_state(self, index, value):
+        self._packed[index] = value
+
+    def getElement_packed_state(self, index):
+        return self._packed[index]
+
+    def getAddr(self):
+        return self._addr
+
+    def get_seq(self):
+        return self._seq
+
+    def get_rssi(self):
+        return self._rssi
+
+    def get_amType(self):
+        return Packets.AM_STATEMSG
 
 
 class SimpleBif(object):
@@ -39,21 +141,21 @@ class SimpleBif(object):
         pass
 
 
-def test_flat_init():
+def test_flat_init(tmp_path):
     testbif = SimpleBif()
-    flat = FlatLogger(bif=testbif, tmp_dir="/tmp/")
+    flat = FlatLogger(bif=testbif, tmp_dir=str(tmp_path))
 
     assert flat.tmp_file is not None
 
 
-def test_flat_send_ack():
+def test_flat_send_ack(tmp_path):
     testbif = MagicMock()
-    flat = FlatLogger(bif=testbif, tmp_dir="/tmp")
+    flat = FlatLogger(bif=testbif, tmp_dir=str(tmp_path))
     flat.send_ack(seq=1, dest=223)
     testbif.sendMsg.assert_called()
 
 
-def test_store_state():
+def test_store_state(tmp_path):
     testbif = MagicMock()
 
     s_msg = StateMsg(addr=22)
@@ -68,7 +170,7 @@ def test_store_state():
 
     m = mock_open()
     with patch("pulp.base.FlatLogger.open", m):
-        flat = FlatLogger(bif=testbif, tmp_dir="/tmp")
+        flat = FlatLogger(bif=testbif, tmp_dir=str(tmp_path))
         flat.store_state(s_msg)
     write_call = m.mock_calls[2]
 
@@ -76,7 +178,7 @@ def test_store_state():
     assert msg_dict["0"] == 25.5
 
 
-def test_mainloop():
+def test_mainloop(tmp_path):
     testbif = SimpleBif()
 
     s_msg = StateMsg(addr=22)
@@ -91,12 +193,30 @@ def test_mainloop():
     testbif.receive(s_msg)
     m = mock_open()
     with patch("pulp.base.FlatLogger.open", m):
-        flat = FlatLogger(bif=testbif, tmp_dir="/tmp")
+        flat = FlatLogger(bif=testbif, tmp_dir=str(tmp_path))
         assert flat.mainloop()
     write_call = m.mock_calls[2]
 
     msg_dict = eval(write_call[1][0])
     assert msg_dict["0"] == 25.5
+
+
+def test_startup_processes_tmp_dir(tmp_path):
+    tmp_dir = tmp_path / "tmp"
+    out_dir = tmp_path / "out"
+    tmp_dir.mkdir()
+    out_dir.mkdir()
+
+    valid = tmp_dir / "valid.log"
+    invalid = tmp_dir / "invalid.log"
+    valid.write_text(json.dumps({"x": 1}) + "\n")
+    invalid.write_text("{bad json}\n")
+
+    FlatLogger(bif=MagicMock(), tmp_dir=str(tmp_dir), out_dir=str(out_dir))
+
+    assert (out_dir / "valid.log").exists()
+    assert not valid.exists()
+    assert not invalid.exists()
 
 
 def tes_t_bif():


### PR DESCRIPTION
## Summary
- ensure `FlatLogger` cleans up leftover files in the temporary directory when starting
- add regression tests for FlatLogger and startup temp-dir handling using lightweight stubs

## Testing
- `PYTHONPATH=. pytest tests/test_flat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a05a181e408327bc8933dcc5d4b1b4