### PR TITLE
Add connection retry for FlatLogger startup

### DIFF
--- a/pulp/base/BaseIF.py
+++ b/pulp/base/BaseIF.py
@@ -9,14 +9,41 @@ from pulp.node import StateMsg, ConfigMsg, Packets, BootMsg
 from tinyos3.message import MoteIF
 import time
 from queue import Queue, Empty
+import logging
 
 
 # Note: MoteIF doesn't currently support coming directly off the serial interface
 #
 class BaseIF(object):
-    def __init__(self, source):
+    def __init__(self, source, retries=5, retry_delay=1.0):
+        """Initialise the TinyOS interface.
+
+        Occasionally the serial forwarder is not ready when this class is
+        created which results in a ``ConnectionRefusedError`` bubbling out of
+        the tinyos packet code.  To make the start up sequence more robust we
+        catch that error and retry a few times with a short delay between
+        attempts.
+
+        :param source: Serial forwarder source string.
+        :param retries: Number of connection attempts before giving up.
+        :param retry_delay: Delay in seconds between retries.
+        """
+
         self.mif = MoteIF.MoteIF()
-        self.source = self.mif.addSource(source)
+        attempt = 0
+        while True:
+            try:
+                self.source = self.mif.addSource(source)
+                break
+            except OSError as err:
+                attempt += 1
+                if attempt > retries:
+                    raise
+                logging.getLogger(__name__).warning(
+                    "Connection to %s refused, retrying in %s seconds", source, retry_delay
+                )
+                time.sleep(retry_delay)
+
         self.mif.addListener(self, StateMsg)
         self.mif.addListener(self, BootMsg)
         self.queue = Queue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import sys
+import types
+
+# Provide minimal tinyos3 stub so that pulp.node imports work during tests
+moteif_mod = types.ModuleType("tinyos3.message.MoteIF")
+
+
+class DummySource:
+    def isDone(self):
+        return False
+
+
+class DummyMoteIF:
+    def addSource(self, source):
+        return DummySource()
+
+    def addListener(self, listener, msgType):
+        pass
+
+    def sendMsg(self, source, dest, amType, group, msg):
+        pass
+
+    def finishAll(self):
+        pass
+
+
+moteif_mod.MoteIF = DummyMoteIF
+
+message_mod = types.ModuleType("tinyos3.message.Message")
+
+
+class DummyMessage:
+    def __init__(self, data="", addr=None, gid=None, base_offset=0, data_length=None):
+        pass
+
+
+message_mod.Message = DummyMessage
+
+message_pkg = types.ModuleType("tinyos3.message")
+message_pkg.MoteIF = moteif_mod
+message_pkg.Message = message_mod
+
+package = types.ModuleType("tinyos3")
+package.message = message_pkg
+
+sys.modules.setdefault("tinyos3", package)
+sys.modules.setdefault("tinyos3.message", message_pkg)
+sys.modules.setdefault("tinyos3.message.MoteIF", moteif_mod)
+sys.modules.setdefault("tinyos3.message.Message", message_mod)

--- a/tests/test_baseif_retry.py
+++ b/tests/test_baseif_retry.py
@@ -1,0 +1,22 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Access stub module prepared in conftest
+moteif_mod = sys.modules["tinyos3.message.MoteIF"]
+MoteIFClass = MagicMock()
+moteif_mod.MoteIF = MoteIFClass
+
+from pulp.base.BaseIF import BaseIF
+
+
+def test_retry_on_connection_refused():
+    mif_instance = MagicMock()
+    source_obj = MagicMock()
+    mif_instance.addSource.side_effect = [ConnectionRefusedError, source_obj]
+    MoteIFClass.return_value = mif_instance
+
+    with patch("time.sleep") as sleep:
+        BaseIF("sf@localhost:9002", retries=2, retry_delay=0.1)
+
+    assert mif_instance.addSource.call_count == 2
+    sleep.assert_called_once()


### PR DESCRIPTION
## Summary
- handle serial forwarder connection failures and retry with delay
- add tests covering BaseIF retry logic

## Testing
- `pytest tests/test_baseif_retry.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'paho')*


------
https://chatgpt.com/codex/tasks/task_e_68a3028abb308327ab931744be9e12af